### PR TITLE
python里worker id的守护线程注册

### DIFF
--- a/Python/source/idregister.py
+++ b/Python/source/idregister.py
@@ -76,7 +76,10 @@ class Register:
 
         self.worker_id = self.__get_next_worker_id()
         if self.worker_id > -1:
-            Thread(target=extern_life, args=[self.worker_id]).start()
+            thread = Thread(target=extern_life, args=[self.worker_id])
+            thread.daemon = True    # 设置为守护线程，系统退出时自动退出
+            thread.start()
+
         return self.worker_id
 
     def __get_next_worker_id(self):


### PR DESCRIPTION
不用再调用register.stop()

注册worker id的线程会随主程序的结束而自动结束

附上一篇 python守护进程的[知乎文档](https://zhuanlan.zhihu.com/p/115270781)